### PR TITLE
Asserstion Fix

### DIFF
--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -11,7 +11,7 @@ age: 12"""))
     # These "asserts" are used for self-checking and not for an auto-testing
     assert yaml("""name: Alex
 age: 12""") == {'age': 12, 'name': 'Alex'}
-    assert yaml("""name: Alex
+    assert yaml("""name: Alex Fox
 age: 12
 
 class: 12b""") == {'age': 12,


### PR DESCRIPTION
**Line 14**: `    assert yaml("""name: Alex`

The assert statement on line 14 is slightly incorrect and will cause an AssertionError if left unchanged. The function input on line 14 should be corrected to the following:

**Line 14**: `    assert yaml("""name: Alex Fox`